### PR TITLE
resolved other components popping up the date picker by adding z-index

### DIFF
--- a/src/Search.css
+++ b/src/Search.css
@@ -4,6 +4,10 @@
     left: 25%;
     width: 100vw;
     z-index: 100;
+    display: flex;
+    flex-flow: column;
+    width: 579px;
+    background-color: white;
 }
 
 .search > h2 {
@@ -13,7 +17,6 @@
     width: 559px;
     padding: 10px;
     background-color: white;
-
 }
 
 .search > input {
@@ -31,7 +34,8 @@
     text-transform: inherit !important;
     background-color: #ff7779;
     color: white;
-    width: 579px;
+    width: 559px;
+    margin: 10px;
   }
 
 .search > button:hover {

--- a/src/Search.css
+++ b/src/Search.css
@@ -3,6 +3,7 @@
     top: 35px;
     left: 25%;
     width: 100vw;
+    z-index: 100;
 }
 
 .search > h2 {
@@ -12,18 +13,13 @@
     width: 559px;
     padding: 10px;
     background-color: white;
-    position: absolute;
-    left: 0;
-    top: 380px;
+
 }
 
 .search > input {
     width: 539px;
     padding: 20px;
-    position: absolute;
-    left: 0;
     height: 30px;
-    top: 420px;
     border: none;
   }
   
@@ -32,9 +28,6 @@
 }
 
 .search > button {
-    position: absolute;
-    left: 0;
-    top: 480px;
     text-transform: inherit !important;
     background-color: #ff7779;
     color: white;
@@ -45,3 +38,4 @@
     background-color: white;
     color: #ff7779;
 }
+


### PR DESCRIPTION
1. while using the date picker, hovering over card components was causing cards popping up the data picker. I have added a z-index = 10 to the date picker component so that the cards don't pop up that.
2. Due to absolute positioning the date picker and guest selector were separating out. I have fixed that problem also.

# before
<img width="1024" alt="Screenshot 2023-01-01 at 3 23 18 PM (2)" src="https://user-images.githubusercontent.com/97349505/210166862-7d8faea9-be1c-457e-a326-46fd8be39cce.png">
<img width="1026" alt="Screenshot 2023-01-01 at 3 22 41 PM" src="https://user-images.githubusercontent.com/97349505/210166920-18e09441-2b75-497c-88ed-c608664562dd.png">

# after

![Screenshot 2023-01-01 at 3 20 52 PM](https://user-images.githubusercontent.com/97349505/210166972-024ea276-2d2d-4b37-9a04-7426e6a7abcb.png)


